### PR TITLE
Make skill timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Options:
   --help            Display help
 ```
 
+### Environment Variables
+
+- `MCP_SKILL_TIMEOUT_MS` - Timeout in milliseconds for skill execution (default `30000`).
+
 ### Integration with Claude Desktop or JSON configurations Locally
 
 Add to your Claude Desktop configuration (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -58,6 +58,10 @@ Options:
   --help            Display help
 ```
 
+### Environment Variables
+
+- `MCP_SKILL_TIMEOUT_MS` - Timeout in milliseconds for skill execution (default `30000`).
+
 ### Integration with Claude Desktop or JSON configurations Locally
 
 Add to your Claude Desktop configuration (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):

--- a/mcp-server/src/mcp-server.ts
+++ b/mcp-server/src/mcp-server.ts
@@ -45,6 +45,9 @@ import { loadSkills, SkillRegistry } from './skillRegistry.js';
 import { BotManager } from './botManager.js';
 import { initializeChatHistory } from './skills/verified/readChat.js';
 
+// Skill execution timeout in milliseconds (default 30 seconds)
+const SKILL_TIMEOUT_MS = parseInt(process.env.MCP_SKILL_TIMEOUT_MS || '30000', 10) || 30000;
+
 // Parse command line arguments (now optional)
 program
     .option('-p, --port <port>', 'Default Minecraft server port')
@@ -300,11 +303,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
                 throw new Error("No active bot. Please use 'joinGame' first to spawn a bot.");
             }
 
-            // Execute the skill with 30-second timeout
+            // Execute the skill with configurable timeout
             const result = await Promise.race([
                 skill.execute(bot, args),
                 new Promise<never>((_, reject) =>
-                    setTimeout(() => reject(new Error('Skill execution timed out after 30 seconds')), 30000)
+                    setTimeout(
+                        () => reject(new Error(`Skill execution timed out after ${Math.round(SKILL_TIMEOUT_MS / 1000)} seconds`)),
+                        SKILL_TIMEOUT_MS
+                    )
                 )
             ]);
 


### PR DESCRIPTION
## Summary
- allow configuring skill timeout via `MCP_SKILL_TIMEOUT_MS`
- document the new environment variable in READMEs

## Testing
- `npm run build` *(fails: No inputs were found)*
- `npm run build` in `mcp-server` *(fails: cannot find module types)*

------
https://chatgpt.com/codex/tasks/task_e_6860417815a883218750f98562487640